### PR TITLE
add renderCountriesDatalist

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,24 +9,7 @@
   <body>
     <div></div>
     <header class="header">
-      <picture class="logo header__logo">
-        <source
-          srcset="./images/mobile/logo.png 1x, ./images/mobile/logo@2x.png 2x"
-          media="(max-width: 767px)"
-        />
-        <source
-          srcset="./images/desktop/logo.png 1x, ./images/desktop/logo@2x.png 2x"
-          media="(min-width: 1200px)"
-        />
-        <source
-          srcset="./images/tablet/logo.png 1x, ./images/tablet/logo@2x.png 2x"
-          media="(min-width: 768px)"
-        />
-        <img
-          src="./images/desktop/logo.png"
-          sizes="(max-width: 767px) 450px, (min-width: 768px) 354px, (min-width: 1200px) 270px, 100vw"
-        />
-      </picture>
+ 
       <div class="container">
         <h1 class="event-text">
           FIND BEST EVENTS<br />
@@ -59,13 +42,7 @@
               <use href="./images/inline-sprite.svg#icon-polygon"></use>
             </svg>
           </label>
-          <datalist id="countries">
-            <option value="UA">Ukraine</option>
-            <option value="PL">Poland</option>
-            <option value="DE">Germany</option>
-            <option value="BE">Belgium</option>
-            <option value="US">United States Of America</option>
-          </datalist>
+
         </form>
         <div class="overlay"></div>
       </div>

--- a/src/js/components/API/discoveryAPI.js
+++ b/src/js/components/API/discoveryAPI.js
@@ -13,7 +13,12 @@ export default class {
       .then(response => response.json())
       .catch(error => console.error(error));
   }
-
+  //   async fetchDetails(eventID) {
+  //   const url = `${BASIC_URL}events/${eventID}?apikey=${KEY}`;
+  //   return await fetch(url)
+  //     .then(response => response.json())
+  //     .catch(error => console.error(error));
+  // }
   incrementPage() {
     this.page += 1;
   }

--- a/src/js/components/API/main.js
+++ b/src/js/components/API/main.js
@@ -8,6 +8,7 @@ import onSearch from '../search-form/search-form-logic';
 
 
 refs.form.elements.search.addEventListener('input', debounce(onSearch, 500));
+refs.form.elements.country.addEventListener('focus', renderCountriesDatalist);
 
 
 export const event = new api('Concert', 'US');
@@ -26,11 +27,18 @@ export function fetchEvents(event) {
 
 
 fetchEvents(event);
+// event.fetchDetails('G5diZ4VBwFSX2');
 
 refs.paginationList.addEventListener('click', debounce(e => {
   event.page = Number(e.target.textContent) - 1;
   fetchEvents(event);
 }, 250));
+
+function renderCountriesDatalist() {
+  refs.form.insertAdjacentHTML('beforeend', ' <datalist id="countries"><option value="UA">Ukraine</option><option value="PL">Poland</option><option value="DE">Germany</option><option value="BE">Belgium</option><option value="US">United States Of America</option><option value="CA">Canada</option><option value="CN">China</option><option value="GE">Georgia</option><option value="GB">Great Britain</option><option value="IT">Italy</option><option value="RU">Russian Federation</option><option value="ES">Spain</option><option value="SE">Sweden</option><option value="TR">Turkey</option></datalist>');
+ 
+}
+
 
 // const bodyRef = document.querySelector('body');
 // bodyRef.addEventListener('keydown', e => {


### PR DESCRIPTION
При фокусе на инпут с выбором стран открывается список стран. Хотелось бы, конечно, забрать их с бекенда асинхронно, но у нас нет на это доступа, ошибка CORS (видимо, наш бесплатный ключ не дает такого доступа). Событие фокус, чтобы список открывался сказу, еще до ввода текста, а клик сюда не подходит.
Перенесу функцию renderCountriesDatalist, когда в папку dev добавится мой предыдущий пул-реквест с созданной там папкой markup.
Закомментированные изменения в файлах discoveryAPI.js и main.js  - там функции для феча инфы о событии (понадобится при покупке билетов, допустим)
